### PR TITLE
Feature/#1 - 팔로우 기능 구현

### DIFF
--- a/src/navigation/ProfileStackNavigator.tsx
+++ b/src/navigation/ProfileStackNavigator.tsx
@@ -7,6 +7,7 @@ import { CreatePostScreen } from '../screens/community/CreatePostScreen';
 import { SettingsScreen } from '../screens/profile/SettingsScreen';
 import { EditGoalScreen } from '../screens/profile/EditGoalScreen';
 import { ShopScreen } from '../screens/profile/ShopScreen';
+import { FollowListScreen } from '../screens/profile/FollowListScreen';
 import type { ProfileStackParamList } from './types';
 
 const Stack = createNativeStackNavigator<ProfileStackParamList>();
@@ -24,6 +25,7 @@ export const ProfileStackNavigator = () => {
             }}
         >
             <Stack.Screen name="ProfileMain" component={ProfileScreen} />
+            <Stack.Screen name="FollowList" component={FollowListScreen} />
             <Stack.Screen name="MyPosts" component={MyPostsScreen} />
             <Stack.Screen name="AddStory" component={AddStoryScreen} />
             <Stack.Screen name="EditPost" component={CreatePostScreen} />

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -28,6 +28,7 @@ export type CommunityStackParamList = {
  */
 export type ProfileStackParamList = {
     ProfileMain: undefined;
+    FollowList: { type: 'followers' | 'following' };
     MyPosts: undefined;
     AddStory: undefined;
 

--- a/src/screens/profile/FollowListScreen.styles.ts
+++ b/src/screens/profile/FollowListScreen.styles.ts
@@ -1,0 +1,73 @@
+import { StyleSheet } from 'react-native';
+import { COLORS, SPACING } from '../../styles';
+
+export const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: COLORS.white,
+    },
+    header: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingHorizontal: SPACING.md,
+        paddingVertical: SPACING.md,
+        borderBottomWidth: 1,
+        borderBottomColor: COLORS.gray[100],
+    },
+    backButton: {
+        padding: SPACING.xs,
+        width: 40,
+    },
+    backText: {
+        fontSize: 24,
+        color: COLORS.gray[900],
+    },
+    listContent: {
+        padding: SPACING.md,
+    },
+    userItem: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: SPACING.md,
+        borderBottomWidth: 1,
+        borderBottomColor: COLORS.gray[50],
+    },
+    avatarContainer: {
+        width: 50,
+        height: 50,
+        borderRadius: 25,
+        backgroundColor: COLORS.gray[100],
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginRight: SPACING.md,
+    },
+    avatarEmoji: {
+        fontSize: 24,
+    },
+    userInfo: {
+        flex: 1,
+    },
+    nameRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginBottom: 4,
+    },
+    userName: {
+        marginRight: SPACING.sm,
+    },
+    levelBadge: {
+        backgroundColor: COLORS.primary[100],
+        paddingHorizontal: 6,
+        paddingVertical: 2,
+        borderRadius: 4,
+    },
+    levelText: {
+        fontSize: 10,
+        color: COLORS.primary[500],
+        fontWeight: 'bold',
+    },
+    description: {
+        color: COLORS.gray[500],
+    },
+});

--- a/src/screens/profile/FollowListScreen.tsx
+++ b/src/screens/profile/FollowListScreen.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, FlatList, Pressable } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Text } from '../../components';
+import { ProfileStackScreenProps } from '../../navigation/types';
+import { styles } from './FollowListScreen.styles';
+
+type TFollower = {
+    id: string;
+    name: string;
+    avatarEmoji: string;
+    level: number;
+    description: string;
+};
+
+// Mock data
+const mockFollowers: TFollower[] = Array.from({ length: 20 }).map((_, i) => ({
+    id: `user-${i}`,
+    name: `유저 ${i + 1}`,
+    avatarEmoji: ['🐶', '🐱', '🐭', '🐹', '🐰', '🦊', '🐻', '🐼', '🐨', '🐯'][i % 10] || '😀',
+    level: Math.floor(Math.random() * 50) + 1,
+    description: '운동을 좋아하는 헬스인입니다! 💪',
+}));
+
+/**
+ * 팔로워/팔로잉 목록 화면
+ * @author 김동현
+ */
+export const FollowListScreen = ({ navigation, route }: ProfileStackScreenProps<'FollowList'>) => {
+    const { type } = route.params;
+    const title = type === 'followers' ? '팔로워' : '팔로잉';
+
+    const handleBack = () => {
+        navigation.goBack();
+    };
+
+    const handleUserPress = (user: TFollower) => {
+        navigation.navigate('UserStory', {
+            userId: user.id,
+            userName: user.name,
+            userAvatar: user.avatarEmoji,
+        });
+    };
+
+    const renderItem = ({ item }: { item: TFollower }) => (
+        <Pressable style={styles.userItem} onPress={() => handleUserPress(item)}>
+            <View style={styles.avatarContainer}>
+                <Text style={styles.avatarEmoji}>{item.avatarEmoji}</Text>
+            </View>
+            <View style={styles.userInfo}>
+                <View style={styles.nameRow}>
+                    <Text variant="h3" style={styles.userName}>{item.name}</Text>
+                    <View style={styles.levelBadge}>
+                        <Text style={styles.levelText}>Lv.{item.level}</Text>
+                    </View>
+                </View>
+                <Text variant="labelMedium" style={styles.description} numberOfLines={1}>
+                    {item.description}
+                </Text>
+            </View>
+        </Pressable>
+    );
+
+    return (
+        <SafeAreaView style={styles.container} edges={['top']}>
+            <View style={styles.header}>
+                <Pressable onPress={handleBack} style={styles.backButton}>
+                    <Text style={styles.backText}>←</Text>
+                </Pressable>
+                <Text variant="h2">{title}</Text>
+                <View style={{ width: 40 }} />
+            </View>
+
+            <FlatList
+                data={mockFollowers}
+                renderItem={renderItem}
+                keyExtractor={(item) => item.id}
+                contentContainerStyle={styles.listContent}
+            />
+        </SafeAreaView>
+    );
+};
+

--- a/src/screens/profile/ProfileScreen.tsx
+++ b/src/screens/profile/ProfileScreen.tsx
@@ -147,19 +147,19 @@ export const ProfileScreen = ({ navigation }: ProfileScreenProps) => {
                                 </Text>
                             </View>
                             <View style={styles.statDivider} />
-                            <View style={styles.socialStatItem}>
+                            <Pressable style={styles.socialStatItem} onPress={() => navigation.navigate('FollowList', { type: 'followers' })}>
                                 <Text variant="labelLarge">{user.followers}</Text>
                                 <Text variant="labelSmall" style={styles.socialStatLabel}>
                                     팔로워
                                 </Text>
-                            </View>
+                            </Pressable>
                             <View style={styles.statDivider} />
-                            <View style={styles.socialStatItem}>
+                            <Pressable style={styles.socialStatItem} onPress={() => navigation.navigate('FollowList', { type: 'following' })}>
                                 <Text variant="labelLarge">{user.following}</Text>
                                 <Text variant="labelSmall" style={styles.socialStatLabel}>
                                     팔로잉
                                 </Text>
-                            </View>
+                            </Pressable>
                         </View>
                     </View>
 

--- a/src/screens/profile/UserStoryScreen.tsx
+++ b/src/screens/profile/UserStoryScreen.tsx
@@ -14,6 +14,7 @@ export type UserStoryScreenProps = RootStackScreenProps<'UserStory'>;
  */
 export const UserStoryScreen = ({ navigation, route }: UserStoryScreenProps) => {
     const { userId, userName, userAvatar } = route.params;
+    const [isFollowing, setIsFollowing] = React.useState(false);
 
     // Mock Stories for other users
     const stories: TStory[] = [
@@ -28,6 +29,10 @@ export const UserStoryScreen = ({ navigation, route }: UserStoryScreenProps) => 
             storyId: story.id,
             imageUrl: story.imageUrl,
         });
+    };
+
+    const handleFollowPress = () => {
+        setIsFollowing(prev => !prev);
     };
 
     const handleBack = () => {
@@ -53,6 +58,8 @@ export const UserStoryScreen = ({ navigation, route }: UserStoryScreenProps) => 
                 stories={stories}
                 isMyProfile={false}
                 onStoryPress={handleStoryPress}
+                isFollowing={isFollowing}
+                onFollowPress={handleFollowPress}
             />
         </SafeAreaView>
     );

--- a/src/screens/profile/components/StoryHero.styles.ts
+++ b/src/screens/profile/components/StoryHero.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet, Dimensions } from 'react-native';
-import { COLORS, SPACING } from '../../../styles';
+import { COLORS, SPACING, RADIUS } from '../../../styles';
 
 const { height: SCREEN_HEIGHT, width: SCREEN_WIDTH } = Dimensions.get('window');
 
@@ -69,5 +69,29 @@ export const styles = StyleSheet.create({
         textShadowColor: 'rgba(0, 0, 0, 0.5)',
         textShadowOffset: { width: 0, height: 1 },
         textShadowRadius: 4,
+    },
+    followButton: {
+        backgroundColor: COLORS.primary[300],
+        paddingHorizontal: SPACING.md,
+        paddingVertical: SPACING.xs + 2,
+        borderRadius: RADIUS.full,
+        elevation: 2,
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.2,
+        shadowRadius: 1.41,
+    },
+    followingButton: {
+        backgroundColor: COLORS.gray[200],
+        borderWidth: 1,
+        borderColor: COLORS.gray[400],
+    },
+    followButtonText: {
+        color: COLORS.gray[900],
+        fontWeight: '600',
+        fontSize: 14,
+    },
+    followingButtonText: {
+        color: COLORS.gray[700],
     },
 });

--- a/src/screens/profile/components/StoryHero.tsx
+++ b/src/screens/profile/components/StoryHero.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Image } from 'react-native';
+import { View, Image, Pressable } from 'react-native';
 import { Text } from '../../../components';
 import { styles } from './StoryHero.styles';
 
@@ -7,6 +7,9 @@ type StoryHeroProps = {
     userName: string;
     avatarEmoji?: string;
     avatarImageUrl?: string;
+    showFollowButton?: boolean;
+    isFollowing?: boolean;
+    onFollowPress?: () => void;
 };
 
 /**
@@ -19,6 +22,9 @@ export const StoryHero = ({
     userName,
     avatarEmoji = '🧙‍♂️',
     avatarImageUrl,
+    showFollowButton = false,
+    isFollowing = false,
+    onFollowPress,
 }: StoryHeroProps) => {
     return (
         <View style={styles.heroSection}>
@@ -45,9 +51,28 @@ export const StoryHero = ({
                             <Text style={styles.avatarEmoji}>{avatarEmoji}</Text>
                         </View>
                     </View> */}
-                    <Text variant="h2" style={styles.userName}>
-                        {userName}
-                    </Text>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+                        <Text variant="h2" style={styles.userName}>
+                            {userName}
+                        </Text>
+
+                        {showFollowButton && (
+                            <Pressable
+                                onPress={onFollowPress}
+                                style={[
+                                    styles.followButton,
+                                    isFollowing && styles.followingButton
+                                ]}
+                            >
+                                <Text style={[
+                                    styles.followButtonText,
+                                    isFollowing && styles.followingButtonText
+                                ]}>
+                                    {isFollowing ? '팔로잉' : '팔로우'}
+                                </Text>
+                            </Pressable>
+                        )}
+                    </View>
                 </View>
             </View>
         </View>

--- a/src/screens/profile/components/StoryTabContent.styles.ts
+++ b/src/screens/profile/components/StoryTabContent.styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+import { COLORS } from '../../../styles';
+
+export const styles = StyleSheet.create({
+    scrollView: {
+        flex: 1,
+        backgroundColor: COLORS.white,
+    }
+});

--- a/src/screens/profile/components/StoryTabContent.tsx
+++ b/src/screens/profile/components/StoryTabContent.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import { View, ScrollView, StyleSheet } from 'react-native';
+import { ScrollView } from 'react-native';
 import { StoryHero, ActionButtons, StoryGrid, type TStory } from '.';
-import { styles as profileStyles } from '../ProfileScreen.styles';
-
-// Note: storing styles here for now, or importing from ProfileScreen.styles if compatible
-// Ideally ProfileScreen.styles should be split too, but for now we'll reuse or duplicate the container styles needed.
+import { styles } from './StoryTabContent.styles';
 
 type TUser = {
     name: string;
@@ -21,6 +18,9 @@ type StoryTabContentProps = {
     onNewStoryPress?: () => void;
     onDeleteStory?: (storyId: string) => void;
     onStoryPress?: (story: TStory) => void;
+    // Follow functionality
+    isFollowing?: boolean;
+    onFollowPress?: () => void;
 };
 
 /**
@@ -36,6 +36,8 @@ export const StoryTabContent = ({
     onNewStoryPress,
     onDeleteStory,
     onStoryPress,
+    isFollowing,
+    onFollowPress,
 }: StoryTabContentProps) => {
     return (
         <ScrollView style={styles.scrollView} bounces={false}>
@@ -44,6 +46,9 @@ export const StoryTabContent = ({
                 userName={user.name}
                 avatarEmoji={user.avatarEmoji}
                 avatarImageUrl={user.avatarImageUrl}
+                showFollowButton={!isMyProfile}
+                isFollowing={isFollowing}
+                onFollowPress={onFollowPress}
             />
 
             {/* Action Buttons - Only for My Profile */}
@@ -65,9 +70,3 @@ export const StoryTabContent = ({
     );
 };
 
-const styles = StyleSheet.create({
-    scrollView: {
-        flex: 1,
-        backgroundColor: '#FFFFFF', // Or inherit from theme
-    }
-});


### PR DESCRIPTION
## Related Issues

-   Resolves: #1 

## Description

사용자 간 인터랙션을 위해 팔로우/팔로잉 기능을 구현했습니다. 타인 프로필에서의 팔로우 동작과 내 프로필에서의 팔로워/팔로잉 목록 확인 및 이동 기능을 추가했습니다. 또한 프로젝트 코딩 컨벤션에 맞춰 스타일 분리 및 JSDoc 작성을 수행했습니다.

## Tasks

1. 팔로우/팔로잉 목록 화면 (FollowListScreen)
- 기능: 팔로워 및 팔로잉 목록을 하나의 화면에서 타입에 따라 동적으로 표시합니다.
- UI: 사용자 아바타, 이름, 레벨, 상태 메시지를 포함한 리스트 UI를 구현했습니다.
- 네비게이션: 목록의 항목을 클릭하면 해당 사용자의 스토리 화면(UserStoryScreen)으로 이동합니다.
- 리팩토링:  FollowListScreen.styles.ts로 스타일을 분리하였습니다.

2. 타인 프로필 팔로우 기능
- StoryHero 업데이트: 타인 프로필(UserStoryScreen) 진입 시 이름 옆에 '팔로우' 버튼을 추가했습니다.
- 상태 관리: 버튼 클릭 시 팔로우/팔로잉 상태가 토글되도록 구현했습니다 (현재는 로컬 상태로 Mocking).
- StoryTabContent 리팩토링: StoryTabContent.styles.ts로 스타일을 분리하였습니다.

3. 네비게이션 및 진입점
- 프로필 화면 (ProfileScreen): 팔로워/팔로잉 숫자 클릭 시 해당 목록 화면으로 이동하도록 연결했습니다.
- 라우터 업데이트: ProfileStack에 FollowList ({ type: 'followers' | 'following' }) 스크린을 추가했습니다.

## Screenshots

| 내 프로필 (진입점) | 팔로워 목록 | 팔로잉 목록 | 타인 프로필 (팔로우 버튼) |
| :---: | :---: | :---: | :---: |
| <img width="200" src="https://github.com/user-attachments/assets/cfb8baf1-be0f-4158-86b8-0690455fbff1" /> | <img width="200" src="https://github.com/user-attachments/assets/4af5ce47-30bd-4ff4-8c94-bb6d8892de48" /> | <img width="200" src="https://github.com/user-attachments/assets/a9fb5bbc-cfcc-48f0-9d24-7b738f4b68fb" /> | <img width="200" src="https://github.com/user-attachments/assets/aceff9d4-30a9-4733-8bbc-058f6a3d9c27" /> |

## Additional Notes

- [ ] 내 프로필: 팔로워 수 클릭 -> 팔로워 목록 진입 확인
- [ ] 내 프로필: 팔로잉 수 클릭 -> 팔로잉 목록 진입 확인
- [ ] 팔로우 목록: 리스트의 사용자 클릭 -> 해당 사용자 프로필로 이동 확인
- [ ] 타인 프로필: 팔로우 버튼 클릭 -> 팔로잉(회색) / 팔로우(파란색) 토글 확인
