### PR TITLE
Feature/#3 - meal log api

### DIFF
--- a/src/screens/home/DietUploadScreen.tsx
+++ b/src/screens/home/DietUploadScreen.tsx
@@ -1,18 +1,19 @@
 import React, { useState } from 'react';
-import { View, ScrollView, Pressable, TextInput, Alert, Image } from 'react-native';
+import { View, ScrollView, Pressable, TextInput, Alert, Image, ActivityIndicator } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { Text, Button, ScreenLayout } from '../../components';
 import { styles } from './DietUploadScreen.styles';
 import { COLORS } from '../../styles';
+import { useCreateMealLogMutation, useUpdateMealLogMutation } from '../../services/meal/useMealMutation';
+import type { TMealType } from '../../services/meal/types';
 
 type UploadMode = 'photo' | 'manual';
-type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack';
 
-const MEAL_TYPES: { id: MealType; label: string }[] = [
-    { id: 'breakfast', label: '아침' },
-    { id: 'lunch', label: '점심' },
-    { id: 'dinner', label: '저녁' },
-    { id: 'snack', label: '간식' },
+const MEAL_TYPES: { id: TMealType; label: string }[] = [
+    { id: 'BREAKFAST', label: '아침' },
+    { id: 'LUNCH', label: '점심' },
+    { id: 'DINNER', label: '저녁' },
+    { id: 'SNACK', label: '간식' },
 ];
 
 /**
@@ -24,8 +25,6 @@ import type { HomeStackParamList } from '../../navigation/types';
 
 type Props = NativeStackScreenProps<HomeStackParamList, 'DietUpload'>;
 
-// ... imports
-
 /**
  * 식단 업로드 화면
  * @author 김동현
@@ -34,15 +33,32 @@ export const DietUploadScreen = ({ route }: Props) => {
     const navigation = useNavigation();
     const { mode: initialMode, date: dateParam, initialData } = route.params || {};
 
+    // TODO: 실제 userId는 인증 상태에서 가져와야 함
+    const userId = 1;
+
     // Date Formatting
     const dateObj = dateParam ? new Date(dateParam) : new Date();
     const formattedDate = `${dateObj.getFullYear()}년 ${dateObj.getMonth() + 1}월 ${dateObj.getDate()}일`;
+    const apiDateFormat = `${dateObj.getFullYear()}-${String(dateObj.getMonth() + 1).padStart(2, '0')}-${String(dateObj.getDate()).padStart(2, '0')}`;
 
     const [mode, setMode] = useState<UploadMode>(initialMode || 'photo');
-    const [selectedMealType, setSelectedMealType] = useState<MealType>((initialData?.type as MealType) || 'breakfast');
+    const [selectedMealType, setSelectedMealType] = useState<TMealType>(
+        (initialData?.type?.toUpperCase() as TMealType) || 'BREAKFAST'
+    );
     const [foodName, setFoodName] = useState(initialData?.foods?.join(', ') || '');
     const [calories, setCalories] = useState(initialData?.calories ? String(initialData.calories) : '');
+    const [carbs, setCarbs] = useState('');
+    const [protein, setProtein] = useState('');
+    const [fat, setFat] = useState('');
+    const [memo, setMemo] = useState('');
     const [photoUri, setPhotoUri] = useState<string | null>(null);
+
+    // API Mutations
+    const createMutation = useCreateMealLogMutation(userId);
+    const updateMutation = useUpdateMealLogMutation(initialData?.id ? Number(initialData.id) : 0);
+
+    const isEditing = !!initialData?.id;
+    const isLoading = createMutation.isPending || updateMutation.isPending;
 
     const handleTakePhoto = () => {
         // Mock Camera
@@ -56,7 +72,7 @@ export const DietUploadScreen = ({ route }: Props) => {
 
     const handlePickImage = () => {
         // Mock Gallery
-        Alert.alert('갤러리 열기', '갤러리가 행됩니다.', [
+        Alert.alert('갤러리 열기', '갤러리가 실행됩니다.', [
             {
                 text: '선택 (Mock)',
                 onPress: () => setPhotoUri('https://via.placeholder.com/300'),
@@ -64,7 +80,7 @@ export const DietUploadScreen = ({ route }: Props) => {
         ]);
     };
 
-    const handleSubmit = () => {
+    const handleSubmit = async () => {
         if (mode === 'manual') {
             if (!foodName || !calories) {
                 Alert.alert('알림', '음식 이름과 칼로리를 입력해주세요.');
@@ -77,18 +93,33 @@ export const DietUploadScreen = ({ route }: Props) => {
             }
         }
 
-        // TODO: Save logic here
-        console.log('Saving diet entry:', {
-            mode,
+        const mealData = {
+            name: foodName,
+            eatenAt: apiDateFormat,
             mealType: selectedMealType,
-            foodName,
-            calories,
-            photoUri,
-        });
+            memo: memo || undefined,
+            totalKcal: parseInt(calories, 10) || 0,
+            totalCarbG: parseInt(carbs, 10) || 0,
+            totalProteinG: parseInt(protein, 10) || 0,
+            totalFatG: parseInt(fat, 10) || 0,
+        };
 
-        Alert.alert('저장 완료', '식단이 저장되었습니다.', [
-            { text: '확인', onPress: () => navigation.goBack() },
-        ]);
+        try {
+            if (isEditing) {
+                await updateMutation.mutateAsync(mealData);
+                Alert.alert('수정 완료', '식단이 수정되었습니다.', [
+                    { text: '확인', onPress: () => navigation.goBack() },
+                ]);
+            } else {
+                await createMutation.mutateAsync(mealData);
+                Alert.alert('저장 완료', '식단이 저장되었습니다.', [
+                    { text: '확인', onPress: () => navigation.goBack() },
+                ]);
+            }
+        } catch (error) {
+            console.error('MealLog save error:', error);
+            Alert.alert('오류', '식단 저장에 실패했습니다. 다시 시도해주세요.');
+        }
     };
 
     return (
@@ -99,7 +130,7 @@ export const DietUploadScreen = ({ route }: Props) => {
                     <Text style={styles.backIcon}>←</Text>
                 </Pressable>
                 <View style={{ flex: 1 }}>
-                    <Text variant="h3">식단 기록</Text>
+                    <Text variant="h3">{isEditing ? '식단 수정' : '식단 기록'}</Text>
                     <Text variant="bodySmall" style={{ color: COLORS.gray[500] }}>
                         {formattedDate}
                     </Text>
@@ -199,6 +230,39 @@ export const DietUploadScreen = ({ route }: Props) => {
                             />
                         </View>
                         <View style={styles.inputGroup}>
+                            <Text style={styles.label}>탄수화물 (g)</Text>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="0"
+                                placeholderTextColor={COLORS.gray[400]}
+                                keyboardType="numeric"
+                                value={carbs}
+                                onChangeText={setCarbs}
+                            />
+                        </View>
+                        <View style={styles.inputGroup}>
+                            <Text style={styles.label}>단백질 (g)</Text>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="0"
+                                placeholderTextColor={COLORS.gray[400]}
+                                keyboardType="numeric"
+                                value={protein}
+                                onChangeText={setProtein}
+                            />
+                        </View>
+                        <View style={styles.inputGroup}>
+                            <Text style={styles.label}>지방 (g)</Text>
+                            <TextInput
+                                style={styles.input}
+                                placeholder="0"
+                                placeholderTextColor={COLORS.gray[400]}
+                                keyboardType="numeric"
+                                value={fat}
+                                onChangeText={setFat}
+                            />
+                        </View>
+                        <View style={styles.inputGroup}>
                             <Text style={styles.label}>메모 (선택)</Text>
                             <TextInput
                                 style={[styles.input, styles.textArea]}
@@ -206,6 +270,8 @@ export const DietUploadScreen = ({ route }: Props) => {
                                 placeholderTextColor={COLORS.gray[400]}
                                 multiline
                                 numberOfLines={4}
+                                value={memo}
+                                onChangeText={setMemo}
                             />
                         </View>
                     </View>
@@ -216,8 +282,13 @@ export const DietUploadScreen = ({ route }: Props) => {
                     size="large"
                     style={styles.submitButton}
                     onPress={handleSubmit}
+                    disabled={isLoading}
                 >
-                    저장하기
+                    {isLoading ? (
+                        <ActivityIndicator color={COLORS.white} size="small" />
+                    ) : (
+                        isEditing ? '수정하기' : '저장하기'
+                    )}
                 </Button>
             </ScrollView>
         </ScreenLayout>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,3 +5,4 @@
 export * from './apiClient';
 export * from './auth';
 export * from './user';
+export * from './meal';

--- a/src/services/meal/index.ts
+++ b/src/services/meal/index.ts
@@ -1,0 +1,43 @@
+/**
+ * MealLog 서비스
+ * @author 김동현
+ */
+
+import { apiClient } from '../apiClient';
+import type { TMealLogRequestDto, TGetResponse } from './types';
+
+/**
+ * 식단 기록 추가
+ * POST /meal/{userId}
+ * @author 김동현
+ */
+export const createMealLog = async (
+    userId: number,
+    data: TMealLogRequestDto
+): Promise<TGetResponse<number>> => {
+    const response = await apiClient.post<TGetResponse<number>>(`/meal/${userId}`, data);
+    return response.data;
+};
+
+/**
+ * 식단 기록 수정
+ * PATCH /meal/{mealId}
+ * @author 김동현
+ */
+export const updateMealLog = async (
+    mealId: number,
+    data: TMealLogRequestDto
+): Promise<TGetResponse<number>> => {
+    const response = await apiClient.patch<TGetResponse<number>>(`/meal/${mealId}`, data);
+    return response.data;
+};
+
+/**
+ * 식단 기록 삭제
+ * DELETE /meal/{mealId}
+ * @author 김동현
+ */
+export const deleteMealLog = async (mealId: number): Promise<TGetResponse<boolean>> => {
+    const response = await apiClient.delete<TGetResponse<boolean>>(`/meal/${mealId}`);
+    return response.data;
+};

--- a/src/services/meal/types.ts
+++ b/src/services/meal/types.ts
@@ -1,0 +1,51 @@
+/**
+ * MealLog 서비스 타입 정의
+ * @author 김동현
+ */
+
+import type { TGetResponse } from '../user/types';
+
+/**
+ * 식사 타입
+ */
+export type TMealType = 'BREAKFAST' | 'LUNCH' | 'DINNER' | 'SNACK';
+
+/**
+ * 식단 기록 생성/수정 요청 DTO
+ */
+export type TMealLogRequestDto = {
+    /** 식단 이름/메뉴 */
+    name: string;
+    /** 섭취 날짜 (YYYY-MM-DD) */
+    eatenAt: string;
+    /** 식사 타입 */
+    mealType: TMealType;
+    /** 메모 (선택) */
+    memo?: string;
+    /** 총 칼로리 (kcal) */
+    totalKcal: number;
+    /** 총 탄수화물 (g) */
+    totalCarbG: number;
+    /** 총 단백질 (g) */
+    totalProteinG: number;
+    /** 총 지방 (g) */
+    totalFatG: number;
+};
+
+/**
+ * 식단 기록 응답 DTO (추후 조회 API용)
+ */
+export type TMealLogResponseDto = {
+    id: number;
+    name: string;
+    eatenAt: string;
+    mealType: TMealType;
+    memo?: string;
+    totalKcal: number;
+    totalCarbG: number;
+    totalProteinG: number;
+    totalFatG: number;
+    createdAt: string;
+};
+
+export type { TGetResponse };

--- a/src/services/meal/useMealMutation.ts
+++ b/src/services/meal/useMealMutation.ts
@@ -1,0 +1,64 @@
+/**
+ * MealLog 서비스 - TanStack Mutation 훅
+ * @author 김동현
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createMealLog, updateMealLog, deleteMealLog } from './index';
+import type { TMealLogRequestDto } from './types';
+
+/**
+ * MealLog Query Keys 팩토리
+ * @author 김동현
+ */
+export const mealKeys = {
+    all: ['meals'] as const,
+    lists: () => [...mealKeys.all, 'list'] as const,
+    list: (userId: number, date?: string) => [...mealKeys.lists(), userId, date] as const,
+    details: () => [...mealKeys.all, 'detail'] as const,
+    detail: (mealId: number) => [...mealKeys.details(), mealId] as const,
+};
+
+/**
+ * 식단 기록 추가 뮤테이션
+ * @author 김동현
+ */
+export const useCreateMealLogMutation = (userId: number) => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data: TMealLogRequestDto) => createMealLog(userId, data),
+        onSuccess: () => {
+            // 식단 목록 쿼리 무효화
+            queryClient.invalidateQueries({ queryKey: mealKeys.lists() });
+        },
+    });
+};
+
+/**
+ * 식단 기록 수정 뮤테이션
+ * @author 김동현
+ */
+export const useUpdateMealLogMutation = (mealId: number) => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data: TMealLogRequestDto) => updateMealLog(mealId, data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: mealKeys.detail(mealId) });
+            queryClient.invalidateQueries({ queryKey: mealKeys.lists() });
+        },
+    });
+};
+
+/**
+ * 식단 기록 삭제 뮤테이션
+ * @author 김동현
+ */
+export const useDeleteMealLogMutation = () => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: deleteMealLog,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: mealKeys.lists() });
+        },
+    });
+};


### PR DESCRIPTION
## Related Issues

-   Resolves: #7 

## Description

MealLog API를 연동하여 식단 기록 추가/수정/삭제 기능을 구현했습니다.

## Tasks
### 1. MealLog API 연동
- **식단 추가 API** (`POST /meal/{userId}`) - 식단 기록 화면에서 저장 시 호출
- **식단 수정 API** (`PATCH /meal/{mealId}`) - 기존 식단 수정 시 호출
- **식단 삭제 API** (`DELETE /meal/{mealId}`) - 식단 삭제 시 호출

### 2. 식단 입력 폼 개선
- 탄수화물, 단백질, 지방 입력 필드 추가
- 메모 필드 상태 관리 추가
- 수정 모드 지원 (기존 데이터 편집)

### 3. 상태 관리
- TanStack Query Mutation 훅으로 API 호출 관리
- 저장 성공/실패 시 Alert 피드백
- 로딩 상태 처리 (ActivityIndicator)

## Additional Notes

1. **userId 하드코딩**: 현재 `userId = 1`로 하드코딩되어 있습니다. 인증 상태 연동 후 수정 필요
2. **조회 API 미구현**: 백엔드에 `GET /meal/{userId}/{date}` 구현 후 프론트엔드 Query 훅 추가 예정
