### PR TITLE
Fearture/#4 - post & comment api

### DIFF
--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -18,8 +18,8 @@ export type AuthStackParamList = {
  */
 export type CommunityStackParamList = {
     CommunityList: undefined;
-    PostDetail: { postId: string };
-    CreatePost: { category?: string; postId?: string };
+    PostDetail: { postId: string; boardType?: string };
+    CreatePost: { category?: string; postId?: string; boardType?: string };
 };
 
 /**

--- a/src/screens/community/CommunityScreen.tsx
+++ b/src/screens/community/CommunityScreen.tsx
@@ -1,79 +1,21 @@
 import React, { useState } from 'react';
-import { View, ScrollView } from 'react-native';
+import { View, ScrollView, ActivityIndicator } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAtomValue } from 'jotai';
 import { Text } from '../../components';
-import { CategoryTabs, PostCard, FloatingButton, type TPost, type TCategory } from './components';
+import { CategoryTabs, PostCard, FloatingButton, type TCategory } from './components';
 import { StoryGrid, type TStory } from '../profile/components';
 import { styles } from './CommunityScreen.styles';
 import type { CommunityStackScreenProps } from '../../navigation/types';
+import { useGetPostListQuery } from '../../services/post/usePostQuery';
+import { categoryToBoardType, boardTypeToCategory } from '../../services/post/utils';
+import type { TBoardType, TPostResponseDto } from '../../services/post/types';
+import { userIdAtom } from '../../store/authAtom';
+import { COLORS } from '../../styles';
 
 export type CommunityScreenProps = CommunityStackScreenProps<'CommunityList'>;
 
-// Mock 데이터 - 게시글
-const mockPosts: TPost[] = [
-    {
-        id: '1',
-        user: '헬스왕',
-        avatarEmoji: '💪',
-        type: '오운완',
-        category: '운동꿀팁',
-        content: '오늘 가슴 운동 완료! 💪',
-        likes: 24,
-        comments: 3,
-        userLiked: false,
-        time: '2시간 전',
-    },
-    {
-        id: '2',
-        user: '다이어터',
-        avatarEmoji: '🥗',
-        type: '식단공유',
-        category: '식단추천',
-        content: '고단백 저탄고지 점심 - 닭가슴살 샐러드 추천드려요!',
-        likes: 18,
-        comments: 5,
-        userLiked: true,
-        time: '4시간 전',
-    },
-    {
-        id: '3',
-        user: '러닝맨',
-        avatarEmoji: '🏃',
-        type: '오운완',
-        category: '운동꿀팁',
-        content: '아침 10km 러닝 🏃 새벽 공기가 너무 좋았어요',
-        likes: 45,
-        comments: 8,
-        userLiked: false,
-        time: '6시간 전',
-    },
-    {
-        id: '4',
-        user: '초보헬린이',
-        avatarEmoji: '🐣',
-        type: '질문',
-        category: '자유게시판',
-        content: '헬스장 처음 가는데 어떤 운동부터 해야 할까요?',
-        likes: 12,
-        comments: 15,
-        userLiked: false,
-        time: '8시간 전',
-    },
-    {
-        id: '5',
-        user: '영양사언니',
-        avatarEmoji: '👩‍⚕️',
-        type: '정보',
-        category: '식단추천',
-        content: '다이어트 식단에 좋은 단백질 급원 TOP 5를 알려드릴게요!',
-        likes: 67,
-        comments: 22,
-        userLiked: true,
-        time: '1일 전',
-    },
-];
-
-// Mock 데이터 - 랜덤 스토리
+// Mock 데이터 - 랜덤 스토리 (Story API 구현 전까지 유지)
 const mockStories: TStory[] = Array.from({ length: 15 }).map((_, i) => ({
     id: `story-${i}`,
     imageUrl: `https://picsum.photos/400/800?random=${i + 100}`,
@@ -83,19 +25,65 @@ const mockStories: TStory[] = Array.from({ length: 15 }).map((_, i) => ({
 }));
 
 /**
+ * API 응답을 PostCard 형식으로 변환
+ * @author 김동현
+ */
+const transformPostResponse = (post: TPostResponseDto, boardType: TBoardType) => ({
+    id: post.id.toString(),
+    userId: post.userId,
+    user: post.userName,
+    avatarEmoji: '👤',
+    type: post.postType,
+    category: boardTypeToCategory(boardType),
+    content: post.title ? `${post.title}\n${post.content}` : post.content,
+    likes: post.likeCount,
+    comments: post.commentCount,
+    userLiked: post.isLiked,
+    time: formatRelativeTime(post.createdAt),
+});
+
+/**
+ * 상대적 시간 포맷
+ * @author 김동현
+ */
+const formatRelativeTime = (dateString: string): string => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffMinutes < 1) return '방금 전';
+    if (diffMinutes < 60) return `${diffMinutes}분 전`;
+    if (diffHours < 24) return `${diffHours}시간 전`;
+    if (diffDays < 7) return `${diffDays}일 전`;
+    return date.toLocaleDateString('ko-KR');
+};
+
+/**
  * 커뮤니티 화면 (목록)
  * 카테고리 탭 + 소셜 피드 + 새글 작성 FAB
  * @author 김동현
  */
 export const CommunityScreen = ({ navigation }: CommunityScreenProps) => {
     const [selectedCategory, setSelectedCategory] = useState<TCategory>('전체');
+    const userId = useAtomValue(userIdAtom);
 
-    const filteredPosts = selectedCategory === '전체'
-        ? mockPosts
-        : mockPosts.filter((post) => post.category === selectedCategory);
+    // 카테고리에 따른 boardType 결정
+    const boardType = categoryToBoardType(selectedCategory);
+
+    // 전체 조회 시 FREE 게시판 기본 조회 (나중에 여러 boardType 병합 가능)
+    const queryBoardType: TBoardType = boardType || 'FREE';
+
+    const { data, isLoading, isError, refetch } = useGetPostListQuery(
+        queryBoardType,
+        0,
+        20
+    );
 
     const handlePostPress = (postId: string) => {
-        navigation.navigate('PostDetail', { postId });
+        navigation.navigate('PostDetail', { postId, boardType: queryBoardType });
     };
 
     const handleStoryPress = (story: TStory) => {
@@ -110,6 +98,11 @@ export const CommunityScreen = ({ navigation }: CommunityScreenProps) => {
             category: selectedCategory !== '전체' && selectedCategory !== '스토리' ? selectedCategory : undefined,
         });
     };
+
+    // 게시글 변환
+    const posts = data?.success && data.data?.content
+        ? data.data.content.map((post) => transformPostResponse(post, queryBoardType))
+        : [];
 
     return (
         <SafeAreaView style={styles.container}>
@@ -135,16 +128,42 @@ export const CommunityScreen = ({ navigation }: CommunityScreenProps) => {
                             onStoryPress={handleStoryPress}
                         />
                     </View>
+                ) : isLoading ? (
+                    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingVertical: 40 }}>
+                        <ActivityIndicator size="large" color={COLORS.primary[300]} />
+                        <Text variant="bodyMedium" style={{ marginTop: 12, color: COLORS.gray[500] }}>
+                            게시글을 불러오는 중...
+                        </Text>
+                    </View>
+                ) : isError ? (
+                    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingVertical: 40 }}>
+                        <Text variant="bodyMedium" style={{ color: COLORS.gray[500] }}>
+                            게시글을 불러오지 못했습니다
+                        </Text>
+                        <Text
+                            variant="labelMedium"
+                            style={{ color: COLORS.primary[300], marginTop: 8 }}
+                            onPress={() => refetch()}
+                        >
+                            다시 시도
+                        </Text>
+                    </View>
+                ) : posts.length === 0 ? (
+                    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', paddingVertical: 40 }}>
+                        <Text variant="bodyMedium" style={{ color: COLORS.gray[500] }}>
+                            아직 게시글이 없습니다
+                        </Text>
+                    </View>
                 ) : (
                     <View style={styles.feedSection}>
-                        {filteredPosts.map((post) => (
+                        {posts.map((post) => (
                             <PostCard
                                 key={post.id}
                                 post={post}
                                 onPress={() => handlePostPress(post.id)}
                                 onUserPress={() =>
                                     navigation.navigate('UserStory', {
-                                        userId: post.user, // Using username as ID for mock
+                                        userId: post.user,
                                         userName: post.user,
                                         userAvatar: post.avatarEmoji,
                                     })

--- a/src/screens/community/CreatePostScreen.tsx
+++ b/src/screens/community/CreatePostScreen.tsx
@@ -1,45 +1,87 @@
 import React, { useState } from 'react';
 import { View, ScrollView, Pressable, TextInput } from 'react-native';
+import { useAtomValue } from 'jotai';
 import { Text, ScreenLayout } from '../../components';
 import { styles } from './CreatePostScreen.styles';
 import type { CommunityStackScreenProps, ProfileStackScreenProps } from '../../navigation/types';
-import type { TCategory } from './components';
+import { useCreatePostMutation, useUpdatePostMutation } from '../../services/post/usePostMutation';
+import { categoryToBoardType, type TFrontendCategory } from '../../services/post/utils';
+import type { TBoardType } from '../../services/post/types';
+import { userIdAtom } from '../../store/authAtom';
 
 export type CreatePostScreenProps =
     | CommunityStackScreenProps<'CreatePost'>
     | ProfileStackScreenProps<'EditPost'>;
 
-const POST_CATEGORIES: Exclude<TCategory, '전체'>[] = ['운동꿀팁', '식단추천', '자유게시판'];
+type TPostCategory = '운동꿀팁' | '식단추천' | '자유게시판';
+const POST_CATEGORIES: TPostCategory[] = ['운동꿀팁', '식단추천', '자유게시판'];
 
 /**
  * 새 게시글 작성 화면
  * @author 김동현
  */
 export const CreatePostScreen = ({ navigation, route }: CreatePostScreenProps) => {
-    const initialCategory = route.params?.category as TCategory | undefined;
+    const initialCategory = route.params?.category as TPostCategory | undefined;
     const initialContent = (route.params as any)?.initialContent;
     const mode = (route.params as any)?.mode;
+    const editPostId = (route.params as any)?.postId;
     const isEditMode = mode === 'edit';
 
-    const [category, setCategory] = useState<Exclude<TCategory, '전체'> | null>(
-        initialCategory && initialCategory !== '전체' ? initialCategory : null
+    const userId = useAtomValue(userIdAtom);
+
+    const [category, setCategory] = useState<TPostCategory | null>(
+        initialCategory && POST_CATEGORIES.includes(initialCategory as TPostCategory)
+            ? (initialCategory as TPostCategory)
+            : null
     );
+    const [title, setTitle] = useState('');
     const [content, setContent] = useState(initialContent || '');
 
-    const isValid = category !== null && content.trim().length > 0;
+    const createMutation = useCreatePostMutation();
+    const updateMutation = useUpdatePostMutation();
+
+    const isValid = category !== null && title.trim().length > 0 && content.trim().length > 0;
+    const isSubmitting = createMutation.isPending || updateMutation.isPending;
 
     const handleSubmit = () => {
-        if (!isValid) return;
+        if (!isValid || !userId) return;
 
-        // TODO: API 호출하여 게시글 저장
-        if (isEditMode) {
-            console.log('Updating post:', { category, content });
+        const boardType = categoryToBoardType(category as TFrontendCategory) as TBoardType;
+
+        if (isEditMode && editPostId) {
+            updateMutation.mutate(
+                {
+                    boardType,
+                    postId: Number(editPostId),
+                    data: {
+                        userId,
+                        title: title.trim(),
+                        content: content.trim(),
+                    },
+                },
+                {
+                    onSuccess: () => {
+                        navigation.goBack();
+                    },
+                }
+            );
         } else {
-            console.log('Creating post:', { category, content });
+            createMutation.mutate(
+                {
+                    boardType,
+                    data: {
+                        userId,
+                        title: title.trim(),
+                        content: content.trim(),
+                    },
+                },
+                {
+                    onSuccess: () => {
+                        navigation.goBack();
+                    },
+                }
+            );
         }
-
-        // 목록으로 돌아가기
-        navigation.goBack();
     };
 
     return (
@@ -53,17 +95,17 @@ export const CreatePostScreen = ({ navigation, route }: CreatePostScreenProps) =
                     {isEditMode ? '게시글 수정' : '새 글 작성'}
                 </Text>
                 <Pressable
-                    style={[styles.submitButton, !isValid && styles.submitButtonDisabled]}
+                    style={[styles.submitButton, (!isValid || isSubmitting) && styles.submitButtonDisabled]}
                     onPress={handleSubmit}
-                    disabled={!isValid}
+                    disabled={!isValid || isSubmitting}
                 >
                     <Text
                         style={[
                             styles.submitButtonText,
-                            !isValid && styles.submitButtonTextDisabled,
+                            (!isValid || isSubmitting) && styles.submitButtonTextDisabled,
                         ]}
                     >
-                        {isEditMode ? '수정' : '등록'}
+                        {isSubmitting ? '...' : isEditMode ? '수정' : '등록'}
                     </Text>
                 </Pressable>
             </View>
@@ -97,6 +139,20 @@ export const CreatePostScreen = ({ navigation, route }: CreatePostScreenProps) =
                                 </Pressable>
                             ))}
                         </View>
+                    </View>
+
+                    {/* Title Input */}
+                    <View style={styles.inputSection}>
+                        <Text variant="labelLarge" style={styles.label}>
+                            제목
+                        </Text>
+                        <TextInput
+                            style={styles.textInput}
+                            placeholder="제목을 입력하세요..."
+                            value={title}
+                            onChangeText={setTitle}
+                            maxLength={100}
+                        />
                     </View>
 
                     {/* Content Input */}

--- a/src/screens/community/PostDetailScreen.tsx
+++ b/src/screens/community/PostDetailScreen.tsx
@@ -1,76 +1,163 @@
 import React, { useState } from 'react';
-import { View, ScrollView, Pressable, TextInput } from 'react-native';
+import { View, ScrollView, Pressable, TextInput, ActivityIndicator } from 'react-native';
+import { useAtomValue } from 'jotai';
 import { Text, ScreenLayout } from '../../components';
-import { CommentItem, type TComment, CATEGORY_COLORS } from './components';
+import { CommentItem, type TComment, CATEGORY_COLORS, UserAvatar } from './components';
 import { styles } from './PostDetailScreen.styles';
 import type { CommunityStackScreenProps } from '../../navigation/types';
+import { useGetPostQuery } from '../../services/post/usePostQuery';
+import { useLikePostMutation, useUnlikePostMutation } from '../../services/post/usePostMutation';
+import { useGetCommentsQuery } from '../../services/comment/useCommentQuery';
+import { useCreateCommentMutation } from '../../services/comment/useCommentMutation';
+import { boardTypeToCategory } from '../../services/post/utils';
+import type { TBoardType } from '../../services/post/types';
+import { userIdAtom } from '../../store/authAtom';
+import { COLORS } from '../../styles';
 
 export type PostDetailScreenProps = CommunityStackScreenProps<'PostDetail'>;
 
-// Mock 데이터 - 실제로는 postId로 조회
-const getPostById = (postId: string) => ({
-    id: postId,
-    user: '헬스왕',
-    avatarEmoji: '💪',
-    type: '오운완',
-    category: '운동꿀팁' as const,
-    content: '오늘 가슴 운동 완료! 💪\n\n벤치프레스 5세트, 인클라인 덤벨프레스 4세트, 케이블 크로스오버 3세트로 마무리했습니다.\n\n운동 후에는 단백질 섭취 꼭 잊지 마세요!',
-    likes: 24,
-    comments: 3,
-    userLiked: false,
-    time: '2시간 전',
-});
+/**
+ * 상대적 시간 포맷
+ * @author 김동현
+ */
+const formatRelativeTime = (dateString: string): string => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMinutes = Math.floor(diffMs / (1000 * 60));
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-const mockComments: TComment[] = [
-    { id: '1', userName: '런닝맨', avatarEmoji: '🏃', content: '대단하시네요! 저도 오늘 러닝 완료했어요', time: '1시간 전' },
-    { id: '2', userName: '다이어터', avatarEmoji: '🥗', content: '오운완 축하드려요~', time: '30분 전' },
-    { id: '3', userName: '초보헬린이', avatarEmoji: '🐣', content: '세트 구성 참고하겠습니다!', time: '10분 전' },
-];
+    if (diffMinutes < 1) return '방금 전';
+    if (diffMinutes < 60) return `${diffMinutes}분 전`;
+    if (diffHours < 24) return `${diffHours}시간 전`;
+    if (diffDays < 7) return `${diffDays}일 전`;
+    return date.toLocaleDateString('ko-KR');
+};
 
 /**
  * 게시글 상세 화면
  * @author 김동현
  */
 export const PostDetailScreen = ({ navigation, route }: PostDetailScreenProps) => {
-    const { postId } = route.params;
-    const post = getPostById(postId);
+    const { postId, boardType: boardTypeParam } = route.params;
+    const userId = useAtomValue(userIdAtom);
+    const boardType: TBoardType = (boardTypeParam as TBoardType) || 'FREE';
 
-    const [liked, setLiked] = useState(post.userLiked);
-    const [likeCount, setLikeCount] = useState(post.likes);
+    // 게시글 조회
+    const {
+        data: postData,
+        isLoading: isPostLoading,
+        isError: isPostError,
+    } = useGetPostQuery(boardType, Number(postId), userId || 0);
+
+    // 댓글 목록 조회
+    const {
+        data: commentsData,
+        isLoading: isCommentsLoading,
+    } = useGetCommentsQuery(Number(postId), 0, 50);
+
+    // 좋아요 Mutation
+    const likeMutation = useLikePostMutation();
+    const unlikeMutation = useUnlikePostMutation();
+
+    // 댓글 작성 Mutation
+    const createCommentMutation = useCreateCommentMutation();
+
     const [commentText, setCommentText] = useState('');
-    const [comments, setComments] = useState<TComment[]>(mockComments);
+
+    const post = postData?.success ? postData.data : null;
+    const comments: TComment[] = commentsData?.success && commentsData.data?.content
+        ? commentsData.data.content.map((c) => ({
+            id: c.id.toString(),
+            userId: c.userId,
+            userName: `유저${c.userId}`, // TODO: 사용자 이름 조회 필요
+            avatarEmoji: '👤',
+            content: c.content,
+            time: formatRelativeTime(c.createdAt),
+        }))
+        : [];
 
     const handleLikePress = () => {
-        if (liked) {
-            setLikeCount((prev) => prev - 1);
+        if (!userId || !post) return;
+
+        if (post.isLiked) {
+            unlikeMutation.mutate({ boardType, postId: Number(postId), userId });
         } else {
-            setLikeCount((prev) => prev + 1);
+            likeMutation.mutate({ boardType, postId: Number(postId), userId });
         }
-        setLiked(!liked);
     };
 
     const handleSubmitComment = () => {
-        if (!commentText.trim()) return;
+        if (!commentText.trim() || !userId) return;
 
-        const newComment: TComment = {
-            id: Date.now().toString(),
-            userName: '나',
-            avatarEmoji: '😊',
-            content: commentText.trim(),
-            time: '방금 전',
-        };
-        setComments((prev) => [...prev, newComment]);
-        setCommentText('');
+        createCommentMutation.mutate(
+            {
+                postId: Number(postId),
+                data: {
+                    userId,
+                    content: commentText.trim(),
+                },
+            },
+            {
+                onSuccess: () => {
+                    setCommentText('');
+                },
+            }
+        );
     };
 
     const handleUserPress = () => {
-        // 스토리 상세 화면으로 이동
+        if (!post) return;
         navigation.navigate('UserStory', {
-            userId: post.user, // Using username as ID for mock
-            userName: post.user,
-            userAvatar: post.avatarEmoji,
+            userId: post.userId.toString(),
+            userName: post.userName,
+            userAvatar: '👤',
         });
     };
+
+    // 로딩 상태
+    if (isPostLoading) {
+        return (
+            <ScreenLayout style={styles.container} edges={['top']}>
+                <View style={styles.header}>
+                    <Pressable style={styles.backButton} onPress={() => navigation.goBack()}>
+                        <Text style={styles.backText}>←</Text>
+                    </Pressable>
+                    <Text variant="h2" style={styles.headerTitle}>
+                        게시글
+                    </Text>
+                </View>
+                <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+                    <ActivityIndicator size="large" color={COLORS.primary[300]} />
+                </View>
+            </ScreenLayout>
+        );
+    }
+
+    // 에러 상태
+    if (isPostError || !post) {
+        return (
+            <ScreenLayout style={styles.container} edges={['top']}>
+                <View style={styles.header}>
+                    <Pressable style={styles.backButton} onPress={() => navigation.goBack()}>
+                        <Text style={styles.backText}>←</Text>
+                    </Pressable>
+                    <Text variant="h2" style={styles.headerTitle}>
+                        게시글
+                    </Text>
+                </View>
+                <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+                    <Text variant="bodyMedium" style={{ color: COLORS.gray[500] }}>
+                        게시글을 불러오지 못했습니다
+                    </Text>
+                </View>
+            </ScreenLayout>
+        );
+    }
+
+    const category = boardTypeToCategory(boardType);
+    const categoryColor = CATEGORY_COLORS[category] || COLORS.gray[500];
 
     return (
         <ScreenLayout style={styles.container} edges={['top']}>
@@ -92,46 +179,54 @@ export const PostDetailScreen = ({ navigation, route }: PostDetailScreenProps) =
                             style={{ flexDirection: 'row', alignItems: 'center', flex: 1 }}
                             onPress={handleUserPress}
                         >
-                            <View style={styles.avatar}>
-                                <Text style={styles.avatarEmoji}>{post.avatarEmoji}</Text>
-                            </View>
+                            <UserAvatar userId={post.userId} size="large" />
                             <View style={styles.authorDetails}>
                                 <Text variant="labelLarge" style={styles.authorName}>
-                                    {post.user}
+                                    {post.userName}
                                 </Text>
                                 <Text variant="labelSmall" style={styles.postTime}>
-                                    {post.time}
+                                    {formatRelativeTime(post.createdAt)}
                                 </Text>
                             </View>
                         </Pressable>
-                        <View style={styles.categoryBadge(CATEGORY_COLORS[post.category])}>
+                        <View style={styles.categoryBadge(categoryColor)}>
                             <Text
                                 variant="labelSmall"
-                                style={styles.categoryText(CATEGORY_COLORS[post.category])}
+                                style={styles.categoryText(categoryColor)}
                             >
-                                {post.category}
+                                {category}
                             </Text>
                         </View>
                     </View>
+
+                    {post.title && (
+                        <Text variant="h3" style={{ marginBottom: 8 }}>
+                            {post.title}
+                        </Text>
+                    )}
 
                     <Text variant="bodyMedium" style={styles.postContent}>
                         {post.content}
                     </Text>
 
                     <View style={styles.actions}>
-                        <Pressable style={styles.actionButton} onPress={handleLikePress}>
-                            <Text>{liked ? '❤️' : '🤍'}</Text>
+                        <Pressable
+                            style={styles.actionButton}
+                            onPress={handleLikePress}
+                            disabled={likeMutation.isPending || unlikeMutation.isPending}
+                        >
+                            <Text>{post.isLiked ? '❤️' : '🤍'}</Text>
                             <Text
                                 variant="labelMedium"
-                                style={[styles.actionText, liked && styles.actionTextActive]}
+                                style={[styles.actionText, post.isLiked && styles.actionTextActive]}
                             >
-                                {likeCount}
+                                {post.likeCount}
                             </Text>
                         </Pressable>
                         <View style={styles.actionButton}>
                             <Text>💬</Text>
                             <Text variant="labelMedium" style={styles.actionText}>
-                                {comments.length}
+                                {post.commentCount}
                             </Text>
                         </View>
                     </View>
@@ -142,7 +237,9 @@ export const PostDetailScreen = ({ navigation, route }: PostDetailScreenProps) =
                     <Text variant="h3" style={styles.commentsHeader}>
                         댓글 {comments.length}
                     </Text>
-                    {comments.length === 0 ? (
+                    {isCommentsLoading ? (
+                        <ActivityIndicator size="small" color={COLORS.primary[300]} />
+                    ) : comments.length === 0 ? (
                         <Text variant="bodyMedium" style={styles.emptyComments}>
                             아직 댓글이 없습니다
                         </Text>
@@ -163,8 +260,14 @@ export const PostDetailScreen = ({ navigation, route }: PostDetailScreenProps) =
                     onChangeText={setCommentText}
                     multiline
                 />
-                <Pressable style={styles.submitButton} onPress={handleSubmitComment}>
-                    <Text style={styles.submitButtonText}>등록</Text>
+                <Pressable
+                    style={styles.submitButton}
+                    onPress={handleSubmitComment}
+                    disabled={createCommentMutation.isPending || !commentText.trim()}
+                >
+                    <Text style={styles.submitButtonText}>
+                        {createCommentMutation.isPending ? '...' : '등록'}
+                    </Text>
                 </Pressable>
             </View>
         </ScreenLayout>

--- a/src/screens/community/components/CommentItem.tsx
+++ b/src/screens/community/components/CommentItem.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { View } from 'react-native';
 import { Text } from '../../../components';
 import { styles } from './CommentItem.styles';
+import { UserAvatar } from './UserAvatar';
 
 export type TComment = {
     id: string;
+    userId: number;
     userName: string;
-    avatarEmoji: string;
+    avatarEmoji?: string;
     content: string;
     time: string;
 };
@@ -22,9 +24,11 @@ type CommentItemProps = {
 export const CommentItem = ({ comment }: CommentItemProps) => {
     return (
         <View style={styles.container}>
-            <View style={styles.avatar}>
-                <Text style={styles.avatarText}>{comment.avatarEmoji}</Text>
-            </View>
+            <UserAvatar
+                userId={comment.userId}
+                size="small"
+                fallbackEmoji={comment.avatarEmoji || '👤'}
+            />
             <View style={styles.content}>
                 <View style={styles.header}>
                     <Text variant="labelMedium" style={styles.userName}>

--- a/src/screens/community/components/PostCard.tsx
+++ b/src/screens/community/components/PostCard.tsx
@@ -3,11 +3,13 @@ import { View, Pressable } from 'react-native';
 import { Text } from '../../../components';
 import { styles } from './PostCard.styles';
 import { type TCategory, CATEGORY_COLORS } from './CategoryTabs';
+import { UserAvatar } from './UserAvatar';
 
 export type TPost = {
     id: string;
+    userId: number;
     user: string;
-    avatarEmoji: string;
+    avatarEmoji?: string;
     type: string;
     category: TCategory;
     content: string;
@@ -32,10 +34,12 @@ export const PostCard = ({ post, onPress, onUserPress }: PostCardProps) => {
         <Pressable style={styles.postCard} onPress={onPress}>
             <View style={styles.postHeader}>
                 <Pressable style={styles.postUserInfo} onPress={onUserPress}>
-                    <View style={styles.postAvatar}>
-                        <Text>{post.avatarEmoji}</Text>
-                    </View>
-                    <View>
+                    <UserAvatar
+                        userId={post.userId}
+                        size="medium"
+                        fallbackEmoji={post.avatarEmoji || '👤'}
+                    />
+                    <View style={{ marginLeft: 8 }}>
                         <Text variant="labelMedium">{post.user}</Text>
                         <Text variant="labelSmall" style={styles.postTime}>
                             {post.time}

--- a/src/screens/community/components/UserAvatar.tsx
+++ b/src/screens/community/components/UserAvatar.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { View, Image, StyleSheet } from 'react-native';
+import { Text } from '../../../components';
+import { useGetUserQuery } from '../../../services/user/useUserQuery';
+import { COLORS } from '../../../styles';
+
+type UserAvatarProps = {
+    userId: number;
+    size?: 'small' | 'medium' | 'large';
+    fallbackEmoji?: string;
+};
+
+const SIZE_MAP = {
+    small: 28,
+    medium: 36,
+    large: 48,
+};
+
+const FONT_SIZE_MAP = {
+    small: 14,
+    medium: 18,
+    large: 24,
+};
+
+/**
+ * 사용자 아바타 컴포넌트
+ * userId로 사용자 정보를 조회하여 프로필 이미지를 표시합니다.
+ * @author 김동현
+ */
+export const UserAvatar = ({ userId, size = 'medium', fallbackEmoji = '👤' }: UserAvatarProps) => {
+    const { data } = useGetUserQuery(userId);
+
+    const avatarSize = SIZE_MAP[size];
+    const fontSize = FONT_SIZE_MAP[size];
+
+    const user = data?.success ? data.data : null;
+    const profileImageUrl = user?.profileImageUrl;
+
+    return (
+        <View style={[styles.container, { width: avatarSize, height: avatarSize, borderRadius: avatarSize / 2 }]}>
+            {profileImageUrl ? (
+                <Image
+                    source={{ uri: profileImageUrl }}
+                    style={[styles.image, { width: avatarSize, height: avatarSize, borderRadius: avatarSize / 2 }]}
+                />
+            ) : (
+                <Text style={[styles.emoji, { fontSize }]}>{fallbackEmoji}</Text>
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        backgroundColor: COLORS.gray[100],
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+    },
+    image: {
+        resizeMode: 'cover',
+    },
+    emoji: {
+        textAlign: 'center',
+    },
+});

--- a/src/screens/community/components/index.ts
+++ b/src/screens/community/components/index.ts
@@ -3,3 +3,5 @@ export { ChallengeChips } from './ChallengeChips';
 export { CategoryTabs, type TCategory, CATEGORY_COLORS } from './CategoryTabs';
 export { FloatingButton } from './FloatingButton';
 export { CommentItem, type TComment } from './CommentItem';
+export { UserAvatar } from './UserAvatar';
+

--- a/src/services/comment/index.ts
+++ b/src/services/comment/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Comment 서비스
+ * @author 김동현
+ */
+
+import { apiClient } from '../apiClient';
+import type {
+    TCommentRequestDto,
+    TCommentResponseDto,
+    TPageResponseDto,
+    TGetResponse,
+} from './types';
+
+/**
+ * 댓글 목록 조회
+ * GET /posts/{postId}/comments
+ * @author 김동현
+ */
+export const getComments = async (
+    postId: number,
+    pageNum: number = 0,
+    size: number = 10
+): Promise<TGetResponse<TPageResponseDto<TCommentResponseDto>>> => {
+    const response = await apiClient.get<TGetResponse<TPageResponseDto<TCommentResponseDto>>>(
+        `/posts/${postId}/comments`,
+        { params: { pageNum, size } }
+    );
+    return response.data;
+};
+
+/**
+ * 댓글 작성
+ * POST /posts/{postId}/comments
+ * @author 김동현
+ */
+export const createComment = async (
+    postId: number,
+    data: TCommentRequestDto
+): Promise<TGetResponse<number>> => {
+    const response = await apiClient.post<TGetResponse<number>>(
+        `/posts/${postId}/comments`,
+        data
+    );
+    return response.data;
+};
+
+/**
+ * 댓글 삭제
+ * DELETE /posts/{postId}/comments/{commentId}/{userId}
+ * @author 김동현
+ */
+export const deleteComment = async (
+    postId: number,
+    commentId: number,
+    userId: number
+): Promise<TGetResponse<boolean>> => {
+    const response = await apiClient.delete<TGetResponse<boolean>>(
+        `/posts/${postId}/comments/${commentId}/${userId}`
+    );
+    return response.data;
+};

--- a/src/services/comment/types.ts
+++ b/src/services/comment/types.ts
@@ -1,0 +1,20 @@
+/**
+ * Comment 서비스 타입 정의
+ * @author 김동현
+ */
+
+export type {
+    TCommentRequestDto,
+    TCommentResponseDto,
+    TPageResponseDto,
+    TGetResponse,
+} from '../post/types';
+
+/**
+ * 댓글 목록 조회 필터
+ */
+export type TCommentFilters = {
+    postId: number;
+    pageNum?: number;
+    size?: number;
+};

--- a/src/services/comment/useCommentMutation.ts
+++ b/src/services/comment/useCommentMutation.ts
@@ -1,0 +1,59 @@
+/**
+ * Comment Mutation 훅
+ * @author 김동현
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createComment, deleteComment } from './index';
+import { commentKeys } from './useCommentQuery';
+import { postKeys } from '../post/usePostQuery';
+import type { TCommentRequestDto } from './types';
+
+/**
+ * 댓글 작성 Mutation
+ * @author 김동현
+ */
+export const useCreateCommentMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ postId, data }: { postId: number; data: TCommentRequestDto }) =>
+            createComment(postId, data),
+        onSuccess: (_, variables) => {
+            // 댓글 목록 갱신
+            queryClient.invalidateQueries({
+                queryKey: commentKeys.list(variables.postId),
+            });
+            // 게시글의 commentCount 갱신을 위해
+            queryClient.invalidateQueries({ queryKey: postKeys.all });
+        },
+    });
+};
+
+/**
+ * 댓글 삭제 Mutation
+ * @author 김동현
+ */
+export const useDeleteCommentMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({
+            postId,
+            commentId,
+            userId,
+        }: {
+            postId: number;
+            commentId: number;
+            userId: number;
+        }) => deleteComment(postId, commentId, userId),
+        onSuccess: (_, variables) => {
+            // 댓글 목록 갱신
+            queryClient.invalidateQueries({
+                queryKey: commentKeys.list(variables.postId),
+            });
+            // 게시글의 commentCount 갱신을 위해
+            queryClient.invalidateQueries({ queryKey: postKeys.all });
+        },
+    });
+};

--- a/src/services/comment/useCommentQuery.ts
+++ b/src/services/comment/useCommentQuery.ts
@@ -1,0 +1,34 @@
+/**
+ * Comment Query 훅
+ * @author 김동현
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { getComments } from './index';
+
+/**
+ * Comment Query Keys 팩토리
+ * @author 김동현
+ */
+export const commentKeys = {
+    all: ['comments'] as const,
+    lists: () => [...commentKeys.all, 'list'] as const,
+    list: (postId: number, pageNum?: number, size?: number) =>
+        [...commentKeys.lists(), { postId, pageNum, size }] as const,
+};
+
+/**
+ * 댓글 목록 조회 쿼리
+ * @author 김동현
+ */
+export const useGetCommentsQuery = (
+    postId: number,
+    pageNum: number = 0,
+    size: number = 10
+) => {
+    return useQuery({
+        queryKey: commentKeys.list(postId, pageNum, size),
+        queryFn: () => getComments(postId, pageNum, size),
+        enabled: !!postId,
+    });
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -6,3 +6,5 @@ export * from './apiClient';
 export * from './auth';
 export * from './user';
 export * from './meal';
+export * from './post';
+export * from './comment';

--- a/src/services/post/index.ts
+++ b/src/services/post/index.ts
@@ -1,0 +1,127 @@
+/**
+ * Post 서비스
+ * @author 김동현
+ */
+
+import { apiClient } from '../apiClient';
+import type {
+    TBoardType,
+    TPostRequestDto,
+    TPostResponseDto,
+    TPageResponseDto,
+    TGetResponse,
+} from './types';
+
+/**
+ * 게시글 목록 조회
+ * GET /boards/{boardType}/posts
+ * @author 김동현
+ */
+export const getPostList = async (
+    boardType: TBoardType,
+    pageNum: number = 0,
+    size: number = 10
+): Promise<TGetResponse<TPageResponseDto<TPostResponseDto>>> => {
+    const response = await apiClient.get<TGetResponse<TPageResponseDto<TPostResponseDto>>>(
+        `/boards/${boardType}/posts`,
+        { params: { pageNum, size } }
+    );
+    return response.data;
+};
+
+/**
+ * 게시글 단건 조회
+ * GET /boards/{boardType}/posts/{postId}/{userId}
+ * @author 김동현
+ */
+export const getPost = async (
+    boardType: TBoardType,
+    postId: number,
+    userId: number
+): Promise<TGetResponse<TPostResponseDto>> => {
+    const response = await apiClient.get<TGetResponse<TPostResponseDto>>(
+        `/boards/${boardType}/posts/${postId}/${userId}`
+    );
+    return response.data;
+};
+
+/**
+ * 게시글 작성
+ * POST /boards/{boardType}/posts
+ * @author 김동현
+ */
+export const createPost = async (
+    boardType: TBoardType,
+    data: TPostRequestDto
+): Promise<TGetResponse<number>> => {
+    const response = await apiClient.post<TGetResponse<number>>(
+        `/boards/${boardType}/posts`,
+        data
+    );
+    return response.data;
+};
+
+/**
+ * 게시글 수정
+ * PUT /boards/{boardType}/posts/{postId}
+ * @author 김동현
+ */
+export const updatePost = async (
+    boardType: TBoardType,
+    postId: number,
+    data: TPostRequestDto
+): Promise<TGetResponse<number>> => {
+    const response = await apiClient.put<TGetResponse<number>>(
+        `/boards/${boardType}/posts/${postId}`,
+        data
+    );
+    return response.data;
+};
+
+/**
+ * 게시글 삭제
+ * DELETE /boards/{boardType}/posts/{postId}/{userId}
+ * @author 김동현
+ */
+export const deletePost = async (
+    boardType: TBoardType,
+    postId: number,
+    userId: number
+): Promise<TGetResponse<boolean>> => {
+    const response = await apiClient.delete<TGetResponse<boolean>>(
+        `/boards/${boardType}/posts/${postId}/${userId}`
+    );
+    return response.data;
+};
+
+/**
+ * 게시글 좋아요
+ * POST /boards/{boardType}/posts/{postId}/like/{userId}
+ * @author 김동현
+ */
+export const likePost = async (
+    boardType: TBoardType,
+    postId: number,
+    userId: number
+): Promise<TGetResponse<boolean>> => {
+    const response = await apiClient.post<TGetResponse<boolean>>(
+        `/boards/${boardType}/posts/${postId}/like/${userId}`
+    );
+    return response.data;
+};
+
+/**
+ * 게시글 좋아요 취소
+ * DELETE /boards/{boardType}/posts/{postId}/like/{userId}
+ * @author 김동현
+ */
+export const unlikePost = async (
+    boardType: TBoardType,
+    postId: number,
+    userId: number
+): Promise<TGetResponse<boolean>> => {
+    const response = await apiClient.delete<TGetResponse<boolean>>(
+        `/boards/${boardType}/posts/${postId}/like/${userId}`
+    );
+    return response.data;
+};

--- a/src/services/post/types.ts
+++ b/src/services/post/types.ts
@@ -1,0 +1,117 @@
+/**
+ * Post 서비스 타입 정의
+ * @author 김동현
+ */
+
+import type { TGetResponse } from '../user/types';
+
+/**
+ * 게시판 타입
+ */
+export type TBoardType = 'TIP' | 'ROUTINE' | 'MEAL' | 'FREE';
+
+/**
+ * 게시글 타입 (콘텐츠 분류)
+ */
+export type TPostType = 'MEAL' | 'WORKOUT' | 'BODY' | 'DAILY';
+
+/**
+ * 게시글 생성/수정 요청 DTO
+ */
+export type TPostRequestDto = {
+    /** 작성자 사용자 ID */
+    userId: number;
+    /** 게시글 타입 */
+    postType?: TPostType;
+    /** 제목 */
+    title: string;
+    /** 내용 */
+    content: string;
+};
+
+/**
+ * 게시글 응답 DTO
+ */
+export type TPostResponseDto = {
+    /** 게시글 ID */
+    id: number;
+    /** 작성자 사용자 ID */
+    userId: number;
+    /** 작성자 이름 */
+    userName: string;
+    /** 게시글 타입 */
+    postType: TPostType;
+    /** 제목 */
+    title: string;
+    /** 내용 */
+    content: string;
+    /** 조회수 */
+    viewCount: number;
+    /** 좋아요 수 */
+    likeCount: number;
+    /** 댓글 수 */
+    commentCount: number;
+    /** 현재 사용자의 좋아요 여부 */
+    isLiked: boolean;
+    /** 작성 일시 */
+    createdAt: string;
+};
+
+/**
+ * 댓글 생성 요청 DTO
+ */
+export type TCommentRequestDto = {
+    /** 댓글 작성자 사용자 ID */
+    userId: number;
+    /** 댓글 내용 */
+    content: string;
+};
+
+/**
+ * 댓글 응답 DTO
+ */
+export type TCommentResponseDto = {
+    /** 댓글 ID */
+    id: number;
+    /** 작성자 사용자 ID */
+    userId: number;
+    /** 댓글 내용 */
+    content: string;
+    /** 작성 일시 */
+    createdAt: string;
+};
+
+/**
+ * 페이지네이션 응답 DTO
+ */
+export type TPageResponseDto<T> = {
+    /** 조회된 데이터 목록 */
+    content: T[];
+    /** 현재 페이지 번호 (0부터 시작) */
+    pageNum: number;
+    /** 페이지 크기 */
+    size: number;
+    /** 전체 데이터 수 */
+    totalElements: number;
+    /** 전체 페이지 수 */
+    totalPages: number;
+    /** 첫 페이지 여부 */
+    first: boolean;
+    /** 마지막 페이지 여부 */
+    last: boolean;
+    /** 다음 페이지 존재 여부 */
+    hasNext: boolean;
+    /** 이전 페이지 존재 여부 */
+    hasPrevious: boolean;
+};
+
+/**
+ * 게시글 목록 조회 필터
+ */
+export type TPostFilters = {
+    boardType: TBoardType;
+    pageNum?: number;
+    size?: number;
+};
+
+export type { TGetResponse };

--- a/src/services/post/usePostMutation.ts
+++ b/src/services/post/usePostMutation.ts
@@ -1,0 +1,117 @@
+/**
+ * Post Mutation 훅
+ * @author 김동현
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createPost, updatePost, deletePost, likePost, unlikePost } from './index';
+import { postKeys } from './usePostQuery';
+import type { TBoardType, TPostRequestDto } from './types';
+
+/**
+ * 게시글 작성 Mutation
+ * @author 김동현
+ */
+export const useCreatePostMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ boardType, data }: { boardType: TBoardType; data: TPostRequestDto }) =>
+            createPost(boardType, data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: postKeys.lists() });
+        },
+    });
+};
+
+/**
+ * 게시글 수정 Mutation
+ * @author 김동현
+ */
+export const useUpdatePostMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({
+            boardType,
+            postId,
+            data,
+        }: {
+            boardType: TBoardType;
+            postId: number;
+            data: TPostRequestDto;
+        }) => updatePost(boardType, postId, data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: postKeys.all });
+        },
+    });
+};
+
+/**
+ * 게시글 삭제 Mutation
+ * @author 김동현
+ */
+export const useDeletePostMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({
+            boardType,
+            postId,
+            userId,
+        }: {
+            boardType: TBoardType;
+            postId: number;
+            userId: number;
+        }) => deletePost(boardType, postId, userId),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: postKeys.lists() });
+        },
+    });
+};
+
+/**
+ * 게시글 좋아요 Mutation
+ * @author 김동현
+ */
+export const useLikePostMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({
+            boardType,
+            postId,
+            userId,
+        }: {
+            boardType: TBoardType;
+            postId: number;
+            userId: number;
+        }) => likePost(boardType, postId, userId),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: postKeys.all });
+        },
+    });
+};
+
+/**
+ * 게시글 좋아요 취소 Mutation
+ * @author 김동현
+ */
+export const useUnlikePostMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({
+            boardType,
+            postId,
+            userId,
+        }: {
+            boardType: TBoardType;
+            postId: number;
+            userId: number;
+        }) => unlikePost(boardType, postId, userId),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: postKeys.all });
+        },
+    });
+};

--- a/src/services/post/usePostQuery.ts
+++ b/src/services/post/usePostQuery.ts
@@ -1,0 +1,53 @@
+/**
+ * Post Query 훅
+ * @author 김동현
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { getPostList, getPost } from './index';
+import type { TBoardType } from './types';
+
+/**
+ * Post Query Keys 팩토리
+ * @author 김동현
+ */
+export const postKeys = {
+    all: ['posts'] as const,
+    lists: () => [...postKeys.all, 'list'] as const,
+    list: (boardType: TBoardType, pageNum?: number, size?: number) =>
+        [...postKeys.lists(), { boardType, pageNum, size }] as const,
+    details: () => [...postKeys.all, 'detail'] as const,
+    detail: (boardType: TBoardType, postId: number, userId: number) =>
+        [...postKeys.details(), { boardType, postId, userId }] as const,
+};
+
+/**
+ * 게시글 목록 조회 쿼리
+ * @author 김동현
+ */
+export const useGetPostListQuery = (
+    boardType: TBoardType,
+    pageNum: number = 0,
+    size: number = 10
+) => {
+    return useQuery({
+        queryKey: postKeys.list(boardType, pageNum, size),
+        queryFn: () => getPostList(boardType, pageNum, size),
+    });
+};
+
+/**
+ * 게시글 단건 조회 쿼리
+ * @author 김동현
+ */
+export const useGetPostQuery = (
+    boardType: TBoardType,
+    postId: number,
+    userId: number
+) => {
+    return useQuery({
+        queryKey: postKeys.detail(boardType, postId, userId),
+        queryFn: () => getPost(boardType, postId, userId),
+        enabled: !!postId && !!userId,
+    });
+};

--- a/src/services/post/utils.ts
+++ b/src/services/post/utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Post 서비스 유틸리티
+ * @author 김동현
+ */
+
+import type { TBoardType } from './types';
+
+/**
+ * 프론트엔드 카테고리 타입
+ */
+export type TFrontendCategory = '전체' | '운동꿀팁' | '식단추천' | '자유게시판' | '스토리';
+
+/**
+ * 프론트엔드 카테고리 → 백엔드 boardType 변환
+ * @author 김동현
+ */
+export const categoryToBoardType = (category: TFrontendCategory): TBoardType | null => {
+    const mapping: Record<TFrontendCategory, TBoardType | null> = {
+        '전체': null, // 전체는 별도 처리 필요
+        '운동꿀팁': 'TIP',
+        '식단추천': 'MEAL',
+        '자유게시판': 'FREE',
+        '스토리': null, // 스토리는 별도 API
+    };
+    return mapping[category];
+};
+
+/**
+ * 백엔드 boardType → 프론트엔드 카테고리 변환
+ * @author 김동현
+ */
+export const boardTypeToCategory = (boardType: TBoardType): TFrontendCategory => {
+    const mapping: Record<TBoardType, TFrontendCategory> = {
+        TIP: '운동꿀팁',
+        MEAL: '식단추천',
+        FREE: '자유게시판',
+        ROUTINE: '운동꿀팁', // ROUTINE은 운동꿀팁으로 매핑
+    };
+    return mapping[boardType];
+};
+
+/**
+ * 게시글 작성 가능한 카테고리 목록
+ */
+export const POST_BOARD_TYPES: TBoardType[] = ['TIP', 'MEAL', 'FREE'];
+
+/**
+ * 카테고리별 색상
+ */
+export const CATEGORY_COLORS: Record<TFrontendCategory, string> = {
+    '전체': '#333333',
+    '운동꿀팁': '#2196F3',
+    '식단추천': '#4CAF50',
+    '자유게시판': '#FF9800',
+    '스토리': '#9C27B0',
+};


### PR DESCRIPTION
## Related Issues

Link the issues this PR resolves.

-   Resolves: #10 

## Description

게시글(Post) 및 댓글(Comment) 서비스 레이어를 구현하고, 커뮤니티 관련 Screen에 API를 연동했습니다.

## Tasks
### 1. Post API 연동
- **게시글 목록 조회** (`GET /boards/{boardType}/posts`) - 커뮤니티 화면
- **게시글 단건 조회** (`GET /boards/{boardType}/posts/{postId}/{userId}`) - 상세 화면
- **게시글 작성/수정/삭제** - 새 글 작성 화면
- **좋아요/좋아요 취소** - 상세 화면
### 2. Comment API 연동
- **댓글 목록 조회** (`GET /posts/{postId}/comments`)
- **댓글 작성** (`POST /posts/{postId}/comments`)
- **댓글 삭제** (`DELETE /posts/{postId}/comments/{commentId}/{userId}`)
### 3. 프로필 이미지 조회
- [UserAvatar] 컴포넌트 신규 생성
- userId로 사용자 정보 조회 → 프로필 이미지 표시
- React Query 캐싱으로 중복 API 요청 방지

## Additional Notes

- Story API (스토리 CRUD)
- 게시글/댓글 응답에 `userProfileImageUrl` 포함 시 N+1 해소 가능

