### PR TITLE
Feature/#5   daily summary api

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -4,6 +4,9 @@ import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { CompositeScreenProps } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
+import { useAtomValue } from 'jotai';
+import { userIdAtom, userInfoAtom } from '../../store';
+import { useGetDailySummaryQuery } from '../../services/dailySummary/useDailySummaryQuery';
 import { styles } from './HomeScreen.styles';
 import type { MainTabParamList, HomeStackParamList } from '../../navigation/types';
 import type { TabKey, Tab, AvatarStats, DailyProgress, Meal, Workout, Routine } from './types';
@@ -16,6 +19,17 @@ import {
 
 const TAB_HEADER_HEIGHT = 48;
 
+/**
+ * 날짜를 YYYY-MM-DD 형식으로 포맷
+ * @author 김동현
+ */
+const formatDate = (date: Date): string => {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+};
+
 export type HomeScreenProps = CompositeScreenProps<
     NativeStackScreenProps<HomeStackParamList, 'HomeMain'>,
     BottomTabScreenProps<MainTabParamList>
@@ -27,7 +41,7 @@ const TABS: Tab[] = [
     { key: 'exercise', label: '운동' },
 ];
 
-// 임시 데이터 - 아바타
+// 임시 데이터 - 아바타 (스탯은 추후 별도 API로 관리 예정)
 const MOCK_STATS: AvatarStats = {
     hp: 75,
     mp: 60,
@@ -37,12 +51,6 @@ const MOCK_STATS: AvatarStats = {
     nextLevelXp: 2000,
 };
 
-const MOCK_DAILY_PROGRESS: DailyProgress = {
-    calories: { current: 1450, target: 2000 },
-    carbs: { current: 180, target: 250 },
-    protein: { current: 95, target: 150 },
-    fat: { current: 45, target: 65 },
-};
 
 // 임시 데이터 - 식단
 const MOCK_TODAY_MEALS: Meal[] = [
@@ -95,6 +103,36 @@ export const HomeScreen = ({ navigation }: HomeScreenProps) => {
     const [selectedDate, setSelectedDate] = useState(new Date());
     const { height: windowHeight } = useWindowDimensions();
     const insets = useSafeAreaInsets();
+
+    // 사용자 정보 가져오기
+    const userId = useAtomValue(userIdAtom);
+    const userInfo = useAtomValue(userInfoAtom);
+
+    // DailySummary API 호출
+    const { data: dailySummary } = useGetDailySummaryQuery(
+        userId ?? 0,
+        formatDate(selectedDate)
+    );
+
+    // 일일 진행 상황 (API 데이터 + 사용자 목표값)
+    const dailyProgress: DailyProgress = useMemo(() => ({
+        calories: {
+            current: dailySummary?.intakeKcal ?? 0,
+            target: userInfo?.goalKcal ?? 2000,
+        },
+        carbs: {
+            current: dailySummary?.intakeCarb ?? 0,
+            target: userInfo?.targetCarb ?? 250,
+        },
+        protein: {
+            current: dailySummary?.intakeProtein ?? 0,
+            target: userInfo?.targetProtein ?? 150,
+        },
+        fat: {
+            current: dailySummary?.intakeFat ?? 0,
+            target: userInfo?.targetFatG ?? 65,
+        },
+    }), [dailySummary, userInfo]);
 
     // Calculate page height (screen - safe areas - tab header)
     const pageHeight = windowHeight - insets.top - insets.bottom - TAB_HEADER_HEIGHT - 60; // 60 = bottom tab bar height
@@ -183,7 +221,7 @@ export const HomeScreen = ({ navigation }: HomeScreenProps) => {
                 {/* 아바타 섹션 */}
                 <AvatarSection
                     stats={MOCK_STATS}
-                    dailyProgress={MOCK_DAILY_PROGRESS}
+                    dailyProgress={dailyProgress}
                     pageHeight={pageHeight}
                 />
 

--- a/src/services/dailySummary/index.ts
+++ b/src/services/dailySummary/index.ts
@@ -1,0 +1,24 @@
+/**
+ * DailySummary 서비스
+ * @author 김동현
+ */
+
+import { apiClient } from '../apiClient';
+import type { TDailySummaryResponseDto, TGetResponse } from './types';
+
+/**
+ * 일일 요약 조회
+ * GET /summary/{userId}/{date}
+ * @param userId 사용자 ID
+ * @param date 조회 날짜 (YYYY-MM-DD)
+ * @author 김동현
+ */
+export const getDailySummary = async (
+    userId: number,
+    date: string
+): Promise<TGetResponse<TDailySummaryResponseDto>> => {
+    const response = await apiClient.get<TGetResponse<TDailySummaryResponseDto>>(
+        `/summary/${userId}/${date}`
+    );
+    return response.data;
+};

--- a/src/services/dailySummary/types.ts
+++ b/src/services/dailySummary/types.ts
@@ -1,0 +1,34 @@
+/**
+ * DailySummary 서비스 타입 정의
+ * @author 김동현
+ */
+
+import type { TGetResponse } from '../user/types';
+
+/**
+ * 일일 요약 응답 DTO
+ */
+export type TDailySummaryResponseDto = {
+    /** 일일 요약 ID */
+    id: number;
+    /** 기록 날짜 (YYYY-MM-DD) */
+    createdAt: string;
+    /** 섭취 칼로리 (kcal) */
+    intakeKcal: number;
+    /** 섭취 탄수화물 (g) */
+    intakeCarb: number;
+    /** 섭취 단백질 (g) */
+    intakeProtein: number;
+    /** 섭취 지방 (g) */
+    intakeFat: number;
+    /** 소모 칼로리 (kcal) */
+    burnedKcal: number;
+    /** 걸음 수 */
+    steps: number;
+    /** 체중 (kg) */
+    weight: number;
+    /** 물 섭취량 (ml) */
+    water: number;
+};
+
+export type { TGetResponse };

--- a/src/services/dailySummary/useDailySummaryQuery.ts
+++ b/src/services/dailySummary/useDailySummaryQuery.ts
@@ -1,0 +1,32 @@
+/**
+ * DailySummary TanStack Query 훅
+ * @author 김동현
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { getDailySummary } from './index';
+
+/**
+ * DailySummary Query Keys 팩토리
+ * @author 김동현
+ */
+export const dailySummaryKeys = {
+    all: ['dailySummary'] as const,
+    detail: (userId: number, date: string) =>
+        [...dailySummaryKeys.all, userId, date] as const,
+};
+
+/**
+ * 일일 요약 조회 쿼리
+ * @param userId 사용자 ID
+ * @param date 조회 날짜 (YYYY-MM-DD)
+ * @author 김동현
+ */
+export const useGetDailySummaryQuery = (userId: number, date: string) => {
+    return useQuery({
+        queryKey: dailySummaryKeys.detail(userId, date),
+        queryFn: () => getDailySummary(userId, date),
+        enabled: !!userId && !!date,
+        select: (response) => response.data,
+    });
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,3 +8,4 @@ export * from './user';
 export * from './meal';
 export * from './post';
 export * from './comment';
+export * from './dailySummary';


### PR DESCRIPTION
## Related Issues

-   Resolves: #11 

## Description

DailySummary API 연동을 통해 일일 섭취/소모 칼로리, 탄단지, 걸음 수, 체중, 물 섭취량 데이터를 서버에서 조회하도록 구현했습니다.

## Tasks

### DailySummary API 연동
- 일일 요약 조회 API (GET /summary/{userId}/{date}) - 홈 화면에서 호출
- 날짜 변경 시 자동으로 해당 날짜의 데이터 리페치

### 서비스 레이어 구현
- TanStack Query 기반 useGetDailySummaryQuery 훅
- Query Key 팩토리 패턴 적용 (dailySummaryKeys)

### HomeScreen 연동
- Mock 데이터(MOCK_DAILY_PROGRESS) 제거
- 사용자 목표값(userInfo)과 API 응답을 결합하여 dailyProgress 동적 생성
- AvatarSection에 실제 데이터 전달

## Additional Notes

- 없습니다.
